### PR TITLE
fix key on repeated elements

### DIFF
--- a/app/imports/components/admin/AdminLayout.jsx
+++ b/app/imports/components/admin/AdminLayout.jsx
@@ -19,8 +19,8 @@ export class AdminLayout extends Component {
       return (
         <section id='admin' className='container admin-container padding-top-small'>
           <div className='admin-posts grid-row'>
-          {this.props.posts.map((post, key) => (
-            <AdminPost post={post} key={key} />
+          {this.props.posts.map((post) => (
+            <AdminPost post={post} key={post._id} />
           ))}
           </div>
 

--- a/app/imports/components/feed/FeedLayout.jsx
+++ b/app/imports/components/feed/FeedLayout.jsx
@@ -52,8 +52,8 @@ export class FeedLayout extends Component {
             <NewPostsNotice newPosts={this.props.newPosts} />
           }
           <div className='feed-posts'>
-            {this.props.posts.map((post, key) => (
-              <FeedPost post={post} key={key} />
+            {this.props.posts.map((post) => (
+              <FeedPost post={post} key={post._id} />
             ))}
           </div>
 


### PR DESCRIPTION
The issue where the image was being repeated after clicking the `<NewPostNotice>` to update is related to how the keys are set. Using the default increasing integer number provided by `map()` was causing the first element to have `key=1` always, resulting in the wrong image being shown.